### PR TITLE
Remove const declaration in bn-to-num

### DIFF
--- a/lib/bn-to-num.js
+++ b/lib/bn-to-num.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const sign = require('./bn-sign')
+var sign = require('./bn-sign')
 
 module.exports = bn2num
 


### PR DESCRIPTION
Remove `const` declaration in favor of a `var` so as not to throw an error in older webkit browsers.

https://bugs.webkit.org/show_bug.cgi?id=161464